### PR TITLE
feat(api): add ProposalService REST API

### DIFF
--- a/src/ContractingService/ContractingService.Api/Controllers/ProposalController.cs
+++ b/src/ContractingService/ContractingService.Api/Controllers/ProposalController.cs
@@ -1,0 +1,46 @@
+﻿namespace ProposalService.Api.Controllers;
+
+using Microsoft.AspNetCore.Mvc;
+using ProposalService.Application.DTOs;
+using ProposalService.Application.Interfaces;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ProposalController : ControllerBase
+{
+    private readonly IProposalAppService _proposalAppService;
+
+    public ProposalController(IProposalAppService proposalAppService)
+    {
+        _proposalAppService = proposalAppService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CustomerDto customer, [FromBody] ContractDto contract)
+    {
+        var result = await _proposalAppService.CreateAsync(customer, contract);
+        return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var result = await _proposalAppService.GetByIdAsync(id);
+        if (result == null) return NotFound();
+        return Ok(result);
+    }
+
+    [HttpPut("{id:guid}/approve")]
+    public async Task<IActionResult> Approve(Guid id)
+    {
+        await _proposalAppService.ApproveAsync(id);
+        return NoContent();
+    }
+
+    [HttpPut("{id:guid}/reject")]
+    public async Task<IActionResult> Reject(Guid id)
+    {
+        await _proposalAppService.RejectAsync(id);
+        return NoContent();
+    }
+}

--- a/src/ContractingService/ContractingService.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ContractingService/ContractingService.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,6 @@
+﻿namespace ProposalService.Api.Extensions
+{
+    public class ServiceCollectionExtensions
+    {
+    }
+}

--- a/src/ProposalService/ProposalService.Api/Contracts/Requests/CreateProposalRequest.cs
+++ b/src/ProposalService/ProposalService.Api/Contracts/Requests/CreateProposalRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace ProposalService.Api.Contracts.Requests;
+
+using ProposalService.Application.DTOs;
+
+public class CreateProposalRequest
+{
+    public CustomerDto Customer { get; set; } = new();
+    public ContractDto Contract { get; set; } = new();
+}

--- a/src/ProposalService/ProposalService.Api/Controllers/ProposalController .cs
+++ b/src/ProposalService/ProposalService.Api/Controllers/ProposalController .cs
@@ -1,0 +1,49 @@
+﻿namespace ProposalService.Api.Controllers;
+
+using Microsoft.AspNetCore.Mvc;
+using ProposalService.Api.Contracts.Requests;
+using ProposalService.Application.Interfaces;
+
+[ApiController]
+[Route("api/v1/proposals")]
+public class ProposalController : ControllerBase
+{
+    private readonly IProposalAppService _proposalAppService;
+
+    public ProposalController(IProposalAppService proposalAppService)
+    {
+        _proposalAppService = proposalAppService;
+    }
+
+    // POST /api/v1/proposals
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateProposalRequest request)
+    {
+        var result = await _proposalAppService.CreateAsync(request.Customer, request.Contract);
+        return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
+    }
+
+    // GET /api/v1/proposals/{id}
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var result = await _proposalAppService.GetByIdAsync(id);
+        return result is null ? NotFound() : Ok(result);
+    }
+
+    // PUT /api/v1/proposals/{id}/approve
+    [HttpPut("{id:guid}/approve")]
+    public async Task<IActionResult> Approve(Guid id)
+    {
+        await _proposalAppService.ApproveAsync(id);
+        return NoContent();
+    }
+
+    // PUT /api/v1/proposals/{id}/reject
+    [HttpPut("{id:guid}/reject")]
+    public async Task<IActionResult> Reject(Guid id)
+    {
+        await _proposalAppService.RejectAsync(id);
+        return NoContent();
+    }
+}

--- a/src/ProposalService/ProposalService.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ProposalService/ProposalService.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace ProposalService.Api.Extensions;
+
+using Microsoft.EntityFrameworkCore;
+using ProposalService.Application.Interfaces;
+using ProposalService.Application.Services;
+using ProposalService.Domain.Interfaces;
+using ProposalService.Infrastructure.Context;
+using ProposalService.Infrastructure.Repositories;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddProposalServices(this IServiceCollection services, IConfiguration cfg)
+    {
+        var conn = cfg.GetConnectionString("DefaultConnection");
+
+        if (string.IsNullOrWhiteSpace(conn))
+        {
+            services.AddDbContext<ProposalDbContext>(o => o.UseInMemoryDatabase("ProposalDb"));
+        }
+        else
+        {
+            services.AddDbContext<ProposalDbContext>(o => o.UseSqlServer(conn));
+        }
+
+        services.AddScoped<IProposalRepository, ProposalRepository>();
+        services.AddScoped<IProposalAppService, ProposalAppService>();
+
+        return services;
+    }
+}

--- a/src/ProposalService/ProposalService.Api/Program.cs
+++ b/src/ProposalService/ProposalService.Api/Program.cs
@@ -1,41 +1,22 @@
+using ProposalService.Api.Extensions;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+// Services
+builder.Services.AddProposalServices(builder.Configuration);
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
+// Pipeline
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
+    app.UseSwagger();
+    app.UseSwaggerUI();
 }
 
 app.UseHttpsRedirection();
-
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast");
-
+app.MapControllers();
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/src/ProposalService/ProposalService.Api/ProposalService.Api.csproj
+++ b/src/ProposalService/ProposalService.Api/ProposalService.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ProposalService/ProposalService.Infrastructure/ProposalService.Infrastructure.csproj
+++ b/src/ProposalService/ProposalService.Infrastructure/ProposalService.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Added ProposalController with endpoints:
  - POST /api/v1/proposals
  - GET /api/v1/proposals/{id}
  - PUT /api/v1/proposals/{id}/approve
  - PUT /api/v1/proposals/{id}/reject
- Introduced CreateProposalRequest as single-body request model
- Registered DI for DbContext, repository, and app service
- Enabled Swagger and controllers pipeline
- Provided appsettings.json with connection string placeholder